### PR TITLE
Feature breadcrumb

### DIFF
--- a/lawnotation-ui/components/Breadcrumb.vue
+++ b/lawnotation-ui/components/Breadcrumb.vue
@@ -1,39 +1,32 @@
 <template>
-  <nav class="flex m-4" aria-label="Breadcrumb">
-    <ol class="inline-flex items-center space-x-1">
-      <li class="inline-flex items-center" v-for="(crumb, i) of props.crumbs" :key="crumb.link">
-        <svg v-if="i > 0" aria-hidden="true" class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
+  <ClientOnly>
+    <Teleport to="#breadcrumb-holder">
+      <nav class="flex m-4" aria-label="Breadcrumb">
+        <ol class="inline-flex items-center space-x-1">
+          <li class="inline-flex items-center" v-for="(crumb, i) of props.crumbs" :key="crumb.link">
+            <svg v-if="i > 0" aria-hidden="true" class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
 
-        <NuxtLink v-if="i < props.crumbs.length-1" :to="crumb.link" class="inline-flex items-center text-sm font-medium text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white">
-          {{ crumb.name }}
-        </NuxtLink>
-        <span v-else class="ml-1 text-sm font-medium text-gray-700 select-none md:ml-2">
-          {{ crumb.name }}
-        </span>
-      </li>
-      <li v-if="false">
-        <div class="flex items-center">
-          <svg aria-hidden="true" class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-          <a href="#" class="ml-1 text-sm font-medium text-gray-700 hover:text-blue-600 md:ml-2 dark:hover:text-white">Projects</a>
-        </div>
-      </li>
-      <li v-if="false">
-        <div class="flex items-center">
-          <svg aria-hidden="true" class="w-6 h-6 text-gray-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"></path></svg>
-          <span class="ml-1 text-sm font-medium text-gray-500 md:ml-2">Flowbite</span>
-        </div>
-      </li>
-    </ol>
-  </nav>
+            <NuxtLink v-if="i < props.crumbs.length-1" :to="crumb.link" class="inline-flex items-center text-sm font-medium text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white">
+              {{ crumb.name }}
+            </NuxtLink>
+            <span v-else class="ml-1 text-sm font-medium text-gray-700 select-none md:ml-2">
+              {{ crumb.name }}
+            </span>
+          </li>
+        </ol>
+      </nav>
+    </Teleport>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">
+export type Crumb = {
+  // icon?: string,
+  name: string,
+  link: string,
+}
 
 const props = defineProps<{
-  crumbs: {
-    icon?: string,
-    name: string,
-    link: string
-  }[]
+  crumbs: Crumb[]
 }>();
 </script>

--- a/lawnotation-ui/layouts/default.vue
+++ b/lawnotation-ui/layouts/default.vue
@@ -2,9 +2,11 @@
 import Header from "@/components/Header.vue";
 import Footer from "@/components/Footer.vue";
 </script>
+
 <template>
   <div>
     <Header></Header>
+    <div id="breadcrumb-holder"></div>
     <div class="mx-auto max-w-screen-lg py-4">
       <slot />
     </div>

--- a/lawnotation-ui/layouts/wide.vue
+++ b/lawnotation-ui/layouts/wide.vue
@@ -5,6 +5,7 @@ import Footer from '@/components/Footer.vue'
 <template>
   <div>
     <Header></Header>
+    <div id="breadcrumb-holder"></div>
     <slot />
     <Footer></Footer>
   </div>

--- a/lawnotation-ui/pages/annotate/[task_id]/index.vue
+++ b/lawnotation-ui/pages/annotate/[task_id]/index.vue
@@ -1,20 +1,20 @@
 <template>
+  <Breadcrumb v-if="task" :crumbs="[
+    {
+      name: 'Tasks',
+      link: '/tasks',
+    },
+    {
+      name: `Task ${task.name}`,
+      link: `/tasks/${task.id}`,
+    },
+    {
+      name: `Assignment ${seq_pos}`,
+      link: `/annotate/${task.id}?seq=${seq_pos}`,
+    }
+  ]" />
+
   <template v-if="assignment && task">
-    
-    <Breadcrumb :crumbs="[
-      {
-        name: 'Tasks',
-        link: '/tasks',
-      },
-      {
-        name: `Task ${task.name}`,
-        link: `/tasks/${task.id}`,
-      },
-      {
-        name: `Assignment ${seq_pos}`,
-        link: `/annotate/${task.id}?seq=${seq_pos}`,
-      }
-    ]" />
 
     <div class="my-4 px-8 flex justify-between">
       <span>&nbsp;</span>

--- a/lawnotation-ui/pages/labelset/[labelset_id].vue
+++ b/lawnotation-ui/pages/labelset/[labelset_id].vue
@@ -1,6 +1,17 @@
 <template>
+  <Breadcrumb v-if="labelset" :crumbs="[
+    {
+      name: 'Labelsets',
+      link: '/labelset',
+    },
+    {
+      name: `Labelset ${labelset.name}`,
+      link: `/labelset/${labelset.id}`
+    }
+  ]" />
+
   <div v-if="labelset === undefined">Loading labelset...</div>
-  <div v-else class="">
+  <div v-else>
     <div class="flex flex-row justify-between">
       <h2 class="text-2xl">Editing labelset: {{ labelset.name }}</h2>
       <button class="btn btn-primary" @click="save_labelset">Save changes</button>

--- a/lawnotation-ui/pages/labelset/index.vue
+++ b/lawnotation-ui/pages/labelset/index.vue
@@ -46,13 +46,9 @@
   </div>
 </template>
 <script setup lang="ts">
-import { Labelset, useLabelsetApi } from "~/data/labelset";
-const route = useRoute();
+import { Labelset } from "~/data/labelset";
 
 const user = useSupabaseUser();
-const labelsetApi = useLabelsetApi();
-
-// const labelsets = ref<Labelset[]>();
 
 const labelsetTable = createTableData<Labelset>(
   {
@@ -78,13 +74,6 @@ const labelsetTable = createTableData<Labelset>(
     filter: () => ({ editor_id: user.value?.id })
   }
 );
-
-onMounted(() => {
-  labelsetApi.findLabelsets().then((_labelsets) => {
-    labelsets.value = [];
-    labelsets.value.push(..._labelsets);
-  });
-});
 
 definePageMeta({
   middleware: ["auth"],

--- a/lawnotation-ui/pages/labelset/new.vue
+++ b/lawnotation-ui/pages/labelset/new.vue
@@ -1,4 +1,15 @@
 <template>
+  <Breadcrumb :crumbs="[
+    {
+      name: 'Labelsets',
+      link: '/labelset',
+    },
+    {
+      name: 'New labelset',
+      link: '/labelset/new'
+    }
+  ]" />
+
   <div class="">
     <div class="flex flex-row justify-between">
       <h2 class="text-2xl">

--- a/lawnotation-ui/pages/projects/[project_id]/documents/[document_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/documents/[document_id]/index.vue
@@ -1,20 +1,40 @@
 <template>
+  <Breadcrumb v-if="project && document" :crumbs="[
+    {
+      name: 'Projects',
+      link: '/projects',
+    },
+    {
+      name: `Project ${project.name}`,
+      link: `/projects/${project.id}`,
+    },
+    {
+      name: `Document ${document.name}`,
+      link: `/projects/${project.id}/documents/${document.id}`,
+    },
+  ]" />
+
   <div>
     <h3 class="text-lg font-semibold mb-2">Document:</h3>
     <pre>{{ document }}</pre>
   </div>
 </template>
 <script setup lang="ts">
+import { Project, useProjectApi } from "~/data/project";
 import { Document, useDocumentApi } from "~/data/document";
 const documentApi = useDocumentApi();
+const projectApi = useProjectApi();
 
 const route = useRoute();
 const document = ref<Document>();
+const project = ref<Project>();
 
-onMounted(() => {
+onMounted(async () => {
   documentApi.findDocument(route.params.document_id.toString()).then((d) => {
     document.value = d;
   });
+
+  project.value = await projectApi.findProject(route.params.project_id as string);
 });
 
 definePageMeta({

--- a/lawnotation-ui/pages/projects/[project_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/index.vue
@@ -1,5 +1,17 @@
-<template>
+<template>  
+  <Breadcrumb v-if="project" :crumbs="[
+    {
+      name: 'Projects',
+      link: '/projects',
+    },
+    {
+      name: `Project ${project.name}`,
+      link: `/projects/${project.id}`,
+    },
+  ]" />
+
   <div v-if="project">
+
     <h1 class="my-3 text-lg font-semibold mb-2">Project: {{ project.name }}</h1>
     <p class="mt-1 mb-3 text-gray-700 text-sm">{{ project.desc }}</p>
 

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -1,4 +1,23 @@
 <template>
+  <Breadcrumb v-if="task && project" :crumbs="[
+    {
+      name: 'Projects',
+      link: '/projects',
+    },
+    {
+      name: `Project ${project.name}`,
+      link: `/projects/${project.id}`,
+    },
+    {
+      name: `Task ${task.name}`,
+      link: `/projects/${project.id}/tasks/${task.id}`,
+    },
+    {
+      name: `Metrics`,
+      link: `/projects/${project.id}/tasks/${task.id}/metrics`,
+    },
+  ]" />
+
   <div class="my-3">
     <div class="flex my-10">
       <div class="mr-5 w-full">
@@ -78,19 +97,19 @@
 import { ExportToCsv } from "export-to-csv";
 import Multiselect from "@vueform/multiselect";
 import { Task, useTaskApi } from "~/data/task";
-import { Assignment, useAssignmentApi } from "~/data/assignment";
 import { Annotation, useAnnotationApi } from "~/data/annotation";
 import { Document, useDocumentApi } from "~/data/document";
 import { Labelset, useLabelsetApi } from "~/data/labelset";
 import { User, useUserApi } from "~/data/user";
 import { result } from "lodash";
+import { Project, useProjectApi } from "~/data/project";
 
 const config = useRuntimeConfig();
 const { $toast } = useNuxtApp();
 
 // const user = useSupabaseUser();
 const taskApi = useTaskApi();
-const assignmentApi = useAssignmentApi();
+const projectApi = useProjectApi();
 const annotationApi = useAnnotationApi();
 const documentApi = useDocumentApi();
 const labelsetApi = useLabelsetApi();
@@ -98,6 +117,7 @@ const userApi = useUserApi();
 
 const route = useRoute();
 const task = ref<Task>();
+const project = ref<Project>();
 
 const documentsOptions = reactive<{ value: string; label: string }[]>([]);
 const selectedDocument = ref<string>();
@@ -206,6 +226,8 @@ const downloadCSV = async () => {
 
 onMounted(async () => {
   task.value = await taskApi.findTask(route.params.task_id.toString());
+  
+  project.value = await projectApi.findProject(route.params.project_id as string);
 
   labelsOptions.push(
     ...(await labelsetApi.findLabelset(task.value.labelset_id.toString())).labels.map(

--- a/lawnotation-ui/pages/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/tasks/[task_id]/index.vue
@@ -1,4 +1,15 @@
 <template>
+  <Breadcrumb v-if="task" :crumbs="[
+    {
+      name: 'Tasks',
+      link: '/tasks',
+    },
+    {
+      name: `Task ${task.name}`,
+      link: `/tasks/${task.id}`,
+    }
+  ]" />
+  
   <div v-if="task">
     <h3 class="my-3 text-lg font-semibold">Task: {{ task.name }}</h3>
     <div class="" v-if="assignmentCounts">
@@ -116,9 +127,7 @@ const assignmentTable = createTableData<AssignmentTableData>(
 );
 
 onMounted(async () => {
-  await taskApi.findTask(route.params.task_id.toString()).then((_task) => {
-    task.value = _task;
-  });
+  task.value = await taskApi.findTask(route.params.task_id as string);
   await loadCounters()
 });
 


### PR DESCRIPTION
This pull request introduces breadcrumbs on every non-toplevel page. Currently, the breadcrumbs are implemented as a concrete component in the page components. I've spent a lot of time into generally implementing the breadcrumbs using layouts and page metadata, but had experienced difficulty including page specific content in the breadcrumb content using this approach. That is, because a lot of data is only available after the onMount, while the content of definePageMeta seems to be executed prior. 