### PR TITLE
Fix loading assignments

### DIFF
--- a/lawnotation-ui/components/Breadcrumb.vue
+++ b/lawnotation-ui/components/Breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <ClientOnly>
-    <Teleport to="#breadcrumb-holder">
+    <Teleport to="body">
       <nav class="flex p-4" aria-label="Breadcrumb">
         <ol class="inline-flex items-center space-x-1">
           <li class="inline-flex items-center" v-for="(crumb, i) of props.crumbs" :key="crumb.link">

--- a/lawnotation-ui/components/Breadcrumb.vue
+++ b/lawnotation-ui/components/Breadcrumb.vue
@@ -1,6 +1,6 @@
 <template>
   <ClientOnly>
-    <Teleport to="body">
+    <Teleport to="#breadcrumb-holder">
       <nav class="flex p-4" aria-label="Breadcrumb">
         <ol class="inline-flex items-center space-x-1">
           <li class="inline-flex items-center" v-for="(crumb, i) of props.crumbs" :key="crumb.link">

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -101,7 +101,8 @@ const user = useSupabaseUser();
 const route = useRoute();
 const task = await $trpc.task.findById.query(+route.params.task_id);
 const project = await $trpc.project.findById.query(+route.params.project_id);
-const totalAssignments = ref<number>(0);
+// const totalAssignments = (await $trpc.assignment.findAssignmentsByTask.query(task.id)).length;
+const totalAssignments = (await $trpc.table.assignments.query({filter: {task_id: task.id}})).total;
 const totalAmountOfDocs = await $trpc.document.totalAmountOfDocs.query(task.project_id);
 const amount_of_docs = totalAmountOfDocs ?? 0;
 const total_docs = amount_of_docs;
@@ -228,10 +229,6 @@ const replicateTask = async () => {
   loading.value = false;
   $toast.success(`Task successfully replicated! ${new_task.id}`);
 };
-
-onMounted(async () => {
-  totalAssignments.value = (await $trpc.assignment.findAssignmentsByTask.query(task.id)).length;
-});
 
 definePageMeta({
   middleware: ["auth",

--- a/lawnotation-ui/pages/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/tasks/[task_id]/index.vue
@@ -47,7 +47,7 @@
           <span>{{ item.difficulty_rating }}</span>
         </td>
         <td class="px-6 py-2">
-          <NuxtLink class="base" :to="`/annotate/${task.data.value.id}?seq=${item.seq_pos}`">
+          <NuxtLink class="base" :to="`/annotate/${task.id}?seq=${item.seq_pos}`">
             View
           </NuxtLink>
         </td>

--- a/lawnotation-ui/pages/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/tasks/[task_id]/index.vue
@@ -87,8 +87,7 @@ const loadCounters = async () => {
 
 onMounted(async () => {
   // task.value = await $trpc.task.findById.query(+route.params.task_id);
-  if (!task)
-    await loadCounters();
+  await loadCounters();
 });
 
 definePageMeta({

--- a/lawnotation-ui/server/trpc/routers/table.router.ts
+++ b/lawnotation-ui/server/trpc/routers/table.router.ts
@@ -30,15 +30,16 @@ const createTableProcedure = <T>(source: TableDataSource) => protectedProcedure
       sort: z.object({
         column: z.string().nullable(),
         dir: z.union([z.literal('ASC'), z.literal('DESC')])
-      }),
+      }).default({column: null, dir: 'ASC'}),
       search: z.object({
         column: z.string().nullable(),
         query: z.string()
-      }),
+      }).default({column: null, query: ""}),
+
       filter: z.record(z.string(), z.any()).optional(),
 
-      page: z.number(),
-      items_per_page: z.number()
+      page: z.number().min(1).default(1),
+      items_per_page: z.number().default(10)
     })
   )
   .output(


### PR DESCRIPTION
This pull-request solves the issue of the assignment-creation form being shown shortly before the data is loaded. For this, some changes are made which need verification, as well as some smaller fixes.

@carloseam94 I moved determination of `totalAmountOfDocs` from onMounted to setup and made them constant and removed the `ref(...)` wrapper. Secondly, it seems the variable `total_docs` is rather redundant. I left it in, but let me know.

@CvdL-UM For determining the `totalAssignments` number, I utilized the table-endpoint, since this will count the total number of entries on database-side, instead of fetching all instances and counting it in the front-end. As was the case with the above point, I also made it constant and removed the `ref`. I tested it and think it will suffice, but please verify.