### PR TITLE
Adding new assignees using invite code

### DIFF
--- a/lawnotation-ui/components/EditorDashboard.vue
+++ b/lawnotation-ui/components/EditorDashboard.vue
@@ -1,5 +1,24 @@
 <template>
   <div>
+    <section
+      class="flex justify-center p-6 py-12 my-5 bg-white border border-gray-200 rounded-lg shadow charts"
+      v-if="nextAssignment"
+    >
+      <div class="">
+        <h2 class="text-2xl font-bold leading-9 tracking-tight text-center text-gray-700">
+          Continue where you left off
+        </h2>
+        <NuxtLink
+          :to="`/annotate/${nextAssignment.task_id}?seq=${nextAssignment.seq_pos}`"
+        >
+          <button
+            class="w-full flex justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600"
+          >
+            Start annotating
+          </button>
+        </NuxtLink>
+      </div>
+    </section>
     <section class="countups my-5 pt-5">
       <div class="flex justify-center text-center">
         <div
@@ -91,6 +110,7 @@
 </template>
 <script setup lang="ts">
 import CountUp from "vue-countup-v3";
+import type { Assignment } from "~/types/assignment";
 
 const { $trpc } = useNuxtApp();
 
@@ -145,6 +165,8 @@ const chartCompletionOptions = ref({
 });
 const chartCompletionSeries = reactive<number[]>([0, 0]);
 
+const nextAssignment = ref<Assignment | null>(null);
+
 onMounted(async () => {
   $trpc.project.getCountByUser.query(user.value?.id!).then((result) => {
     if (result)
@@ -175,6 +197,10 @@ onMounted(async () => {
     for (let i = 0; i < result.length; i++) {
       chartCompletionSeries[i] = result[i].count;
     }
+  });
+
+  $trpc.assignment.findNextAssignmentByUser.query(user.value?.id!).then((result) => {
+    nextAssignment.value = result;
   });
 });
 </script>

--- a/lawnotation-ui/components/EditorDashboard.vue
+++ b/lawnotation-ui/components/EditorDashboard.vue
@@ -1,5 +1,10 @@
 <template>
   <div>
+    <div v-if="alert_assigned_task_id" class="p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400" role="alert">
+      <span class="font-medium">Assign alert!</span>
+      You have been assigned to a new task. <NuxtLink :to="`/annotate/${alert_assigned_task_id}?seq=1`">Click here</NuxtLink> to start annotating
+    </div>
+
     <section
       class="flex justify-center p-6 py-12 my-5 bg-white border border-gray-200 rounded-lg shadow charts"
       v-if="nextAssignment"
@@ -115,6 +120,8 @@ import type { Assignment } from "~/types/assignment";
 const { $trpc } = useNuxtApp();
 
 const user = useSupabaseUser();
+const supa = useSupabaseClient();
+
 const projectsCount = ref<number>(0);
 const tasksCount = ref<number>(0);
 const assignmentsCount = ref<number>(0);
@@ -167,7 +174,15 @@ const chartCompletionSeries = reactive<number[]>([0, 0]);
 
 const nextAssignment = ref<Assignment | null>(null);
 
+const alert_assigned_task_id = ref<number>()
+
 onMounted(async () => {
+  if (user.value?.user_metadata?.assigned_task_id) {
+    alert_assigned_task_id.value = user.value?.user_metadata?.assigned_task_id;
+    await $trpc.user.clearInviteMetadata.mutate();
+    supa.auth.refreshSession()
+  }
+  
   $trpc.project.getCountByUser.query(user.value?.id!).then((result) => {
     if (result)
       projectsCount.value = result;

--- a/lawnotation-ui/components/ExportTaskModal.vue
+++ b/lawnotation-ui/components/ExportTaskModal.vue
@@ -219,7 +219,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ExportTaskOptions } from "~/utils/io";
+import type { ExportTaskOptions } from "~/utils/io";
 import type { Publication } from "~/types"
 const props = defineProps<{
   modelValue: {

--- a/lawnotation-ui/components/Header.vue
+++ b/lawnotation-ui/components/Header.vue
@@ -7,24 +7,22 @@
       <NuxtLink to="/"><img src="/lawnotation-logo.svg" /></NuxtLink>
     </div>
     <div v-if="user" class="space-x-4">
-      <template v-if="role == 'editor'">
-        <NuxtLink
-          to="/projects"
-          class="header-link"
-          :class="{ active: routeIsActive('/projects') }"
-          data-test="projects-link"
-          >Projects</NuxtLink
-        >
-        <span class="text-gray-400 select-none">|</span>
-        <NuxtLink
-          to="/labelset"
-          class="header-link"
-          :class="{ active: routeIsActive('/labelset') }"
-          data-test="labelset-link"
-          >Labelsets</NuxtLink
-        >
-        <span class="text-gray-400 select-none">|</span>
-      </template>
+      <NuxtLink
+        to="/projects"
+        class="header-link"
+        :class="{ active: routeIsActive('/projects') }"
+        data-test="projects-link"
+        >Projects</NuxtLink
+      >
+      <span class="text-gray-400 select-none">|</span>
+      <NuxtLink
+        to="/labelset"
+        class="header-link"
+        :class="{ active: routeIsActive('/labelset') }"
+        data-test="labelset-link"
+        >Labelsets</NuxtLink
+      >
+      <span class="text-gray-400 select-none">|</span>
       <NuxtLink to="/published" class="header-link" :class="{'active': routeIsActive('/published')}">Published Data</NuxtLink>
       <span class="text-gray-400 select-none">|</span>
       <NuxtLink
@@ -61,7 +59,6 @@ const user = useSupabaseUser();
 const { $trpc } = useNuxtApp();
 
 const route = useRoute();
-const role = ref<string>((await $trpc.user.findByEmail.query(user.value!.email!)).role);
 
 const routeIsActive = computed(() => {
   return (match: string) => {

--- a/lawnotation-ui/pages/auth/accept-invite.vue
+++ b/lawnotation-ui/pages/auth/accept-invite.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="flex min-h-screen flex-col justify-center px-6 py-12 lg:px-8 bg-gray-50">
+    <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+      <NuxtLink to="/">
+        <img class="mx-auto h-16 w-auto" src="/lawnotation-logo.svg" alt="Lawnotation" />
+      </NuxtLink>
+      <h2
+        class="mt-8 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"
+      >
+        Enter invitation code
+      </h2>
+      <p class="text-center text-sm text-gray-700">
+        <NuxtLink class="inline-block mt-2 hover:underline" to="/auth/login">Go to login page instead</NuxtLink>
+      </p>
+    </div>
+
+      <div class="mt-8 mx-auto sm:w-full sm:max-w-sm bg-white px-6 py-6 shadow rounded-md">
+        <div class="space-y-3">
+          <p class="block text-sm font-bold">Email address</p>
+          <div class="flex justify-between items-center">
+            <p class="block text-sm font-medium leading-6">{{ email }}</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-6 mx-auto sm:w-full sm:max-w-sm bg-white px-6 py-6 shadow rounded-md">
+        <div class="space-y-4">
+          <label for="token" class="block text-sm font-medium leading-6 text-gray-900"
+            >Enter the 6-digit code</label>
+          <div class="mt-2">
+            <input
+              id="token"
+              name="token"
+              type="text"
+              maxlength="6"
+              v-model="token"
+              @keydown.enter="verifyToken()"
+              required
+              class="block w-full rounded-md border-0 text-xl tracking-widest text-center px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-slate-600 sm:leading-6"
+              data-test="token-field-to-login"
+            />
+          </div>
+          <button
+            :disabled="loading"
+            :class="{ 'cursor-wait': loading }"
+            @click="verifyToken()"
+            type="button"
+            class="flex w-full justify-center rounded-md bg-slate-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-600"
+            data-test="login-button"
+          >
+            <span v-if="!loading">Verify</span>
+            <template v-else>
+              <svg
+                aria-hidden="true"
+                class="inline w-6 h-6 my-1 text-gray-200 animate-spin dark:text-gray-600 fill-slate-400"
+                viewBox="0 0 100 101"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                  fill="currentColor"
+                />
+                <path
+                  d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                  fill="currentFill"
+                />
+              </svg>
+              <span class="sr-only">Loading...</span>
+            </template>
+          </button>
+        </div>
+      </div>
+
+      
+  </div>
+</template>
+<script setup lang="ts">
+const { $toast, $trpc } = useNuxtApp();
+
+const route = useRoute();
+const router = useRouter();
+
+const supabase = useSupabaseClient()
+
+const loading = ref(false);
+
+const email = ref<string>("");
+const token = ref<string>("");
+
+onMounted(() => {
+  try {
+    if (!route.hash || !route.hash.length)
+      throw Error("No email found")
+    // email.value = atob(route.hash.substring(1)) // #user@localhost
+    email.value = route.hash.substring(1) // #user@localhost
+  } catch {
+    $toast.error("Please request a new login code using your email")
+    navigateTo('/auth/login')
+  }
+})
+
+const verifyToken = () => {
+  loading.value = true;
+  supabase.auth
+    .verifyOtp({
+      email: email.value,
+      token: token.value,
+      type: 'email',
+    })
+    .then((verify) => {
+      if (verify.error) {
+        $toast.error(`Error signing in: ${verify.error.message}`);
+        loading.value = false;
+      } else {
+        $toast.success("Logged in successfully");
+        location.href='/'
+      }
+    })
+    .catch((error) => {
+      $toast.error(`Error signing in: ${error.message}`);
+      loading.value = false;
+    })
+}
+
+definePageMeta({
+  layout: "blank",
+  middleware: async () => {
+    const client = useSupabaseClient();
+    const {data: {user: user}} = await client.auth.getUser();
+
+    if (user) location.href = '/';
+  }
+});
+</script>

--- a/lawnotation-ui/pages/index.vue
+++ b/lawnotation-ui/pages/index.vue
@@ -1,8 +1,7 @@
 <template>
   <div>
-    <EditorDashboard v-if="user && role == 'editor'" />
-    <AnnotatorDashboard v-else-if="user && role == 'annotator'" />
-    <div v-else></div>
+    <EditorDashboard />
+    <!-- <AnnotatorDashboard /> -->
   </div>
 </template>
 <script setup lang="ts">
@@ -10,10 +9,6 @@ const user = useSupabaseUser();
 const role = ref<string>();
 
 const { $trpc } = useNuxtApp();
-
-onMounted(async () => {
-  role.value = (await $trpc.user.findByEmail.query(user.value!.email!)).role!;
-});
 
 definePageMeta({
   middleware: ['auth']

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -216,14 +216,14 @@ const createAssignments = async () => {
     }
 
     // Get Users
-    const usersPromises: Promise<User>[] = [];
+    const usersPromises: Promise<User['id']>[] = [];
     for (let i = 0; i < annotators_email.length; ++i) {
       usersPromises.push(
-        $trpc.user.otpLogin.query({ email: annotators_email[i], redirectTo: `${config.public.baseURL}/annotate/${task.id}?seq=1` })
+        $trpc.assignment.assignUserToTask.query({ email: annotators_email[i], task_id: task.id })
       );
     }
 
-    const annotators_id = (await Promise.all(usersPromises)).map((u) => u.id);
+    const annotators_id = (await Promise.all(usersPromises));
 
     // Assign users and order to assignments
     const unshuffled: number[] = [

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -96,7 +96,15 @@
   </div>
 </template>
 <script setup lang="ts">
-import { Task, Assignment, AssignmentTableData, User, Project, Publication, PublicationStatus } from "~/types";
+import type {
+  Task,
+  Assignment,
+  AssignmentTableData,
+  User,
+  Project,
+  Publication,
+} from "~/types";
+import { PublicationStatus } from "~/types"
 import Table from "~/components/Table.vue";
 import { Modal } from "flowbite";
 import { shuffle, clone } from "lodash";

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -242,6 +242,8 @@ const createAssignments = async () => {
       // @ts-expect-error
       new_assignments[i].annotator_id = annotators_id[i % annotators_id.length];
       // @ts-expect-error
+      new_assignments[i].annotator_number = (i % annotators_id.length) + 1
+      // @ts-expect-error
       new_assignments[i].seq_pos =
         (permutations[i % annotators_id.length].pop() ?? Math.floor(i / annotators_id.length)) + 1;
     }

--- a/lawnotation-ui/server/trpc/routers/assignment.router.ts
+++ b/lawnotation-ui/server/trpc/routers/assignment.router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { authorizer, protectedProcedure, router } from "~/server/trpc";
 import type { Assignment } from "~/types";
 import type { Context } from "../context";
+import { zValidEmail } from "~/utils/validators";
 
 const ZAssignmentFields = z.object({
   annotator_id: z.string(),
@@ -336,14 +337,14 @@ export const assignmentRouter = router({
         .order("task_id", { ascending: false })
         .order("seq_pos", { ascending: true })
         .limit(1)
-        .single();
+        .maybeSingle();
 
       if (error)
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: `Error in findNextAssignmentByUser: ${error.message}`,
         });
-      return data as Assignment;
+      return data as Assignment | null;
     }),
 
   countAssignmentsByUserAndTask: protectedProcedure

--- a/lawnotation-ui/server/trpc/routers/assignment.router.ts
+++ b/lawnotation-ui/server/trpc/routers/assignment.router.ts
@@ -52,7 +52,7 @@ export const assignmentRouter = router({
       let user_id: User['id'] | null = null;
       if (!email_found.data) {
         // email is a new user
-        const invite = await serviceClient.auth.admin.inviteUserByEmail(input.email, {data: {invited_task_id: input.task_id}})
+        const invite = await serviceClient.auth.admin.inviteUserByEmail(input.email, {data: {assigned_task_id: input.task_id}})
 
         if (invite.error)
           throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error inviting: ${invite.error.message}`});

--- a/lawnotation-ui/server/trpc/routers/assignment.router.ts
+++ b/lawnotation-ui/server/trpc/routers/assignment.router.ts
@@ -57,10 +57,12 @@ export const assignmentRouter = router({
         if (invite.error)
           throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error inviting: ${invite.error.message}`});
         
-        user_id = invite.data.user.id;
+        user_id = invite.data.user.id as string;
       } else {
         // email is already an user
-        user_id = email_found.data.id;
+        user_id = email_found.data.id as string;
+
+        await serviceClient.auth.admin.updateUserById(user_id, {user_metadata: {assigned_task_id: input.task_id}})
       
         // ...
         console.log("Hypothetically sending notification to user that it is assigned to new task")  

--- a/lawnotation-ui/server/trpc/routers/task.router.ts
+++ b/lawnotation-ui/server/trpc/routers/task.router.ts
@@ -100,7 +100,7 @@ export const taskRouter = router({
           for (let j = 0; j < assignments.length; j++) {
               const ass = assignments[j];
               try {
-                  await caller.assignment.update({ id: ass.id, updates: { ...ass, annotator_id: new_user } });
+                  await caller.assignment.update({ id: ass.id, updates: { annotator_id: new_user } });
                   stats.success++;
               } catch {
                   stats.failed++;

--- a/lawnotation-ui/server/trpc/routers/task.router.ts
+++ b/lawnotation-ui/server/trpc/routers/task.router.ts
@@ -68,6 +68,64 @@ export const taskRouter = router({
   //     return data as Task[];
   //   }),
 
+  updateAssignees: protectedProcedure
+    .input(
+      z.object({
+        task_id: z.number(),
+        new_emails: z.array(z.union([zValidEmail, z.literal("")]))
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const caller = appRouter.createCaller(ctx);
+
+      const stats = {
+        success: 0,
+        failed: 0
+      };
+      
+      const annotators = await caller.task.getAllAnnotatorsFromTask(input.task_id)
+
+      for (let i = 0; i < input.new_emails.length; i++) {
+        if (input.new_emails[i] != annotators[i].email) {
+          const assignments = await caller.assignment.findAssignmentsByTaskAndUser({
+              annotator_number: annotators[i].annotator_number,
+              task_id: input.task_id
+          });
+
+          let new_user = null;
+          if (input.new_emails[i] && input.new_emails.length) {
+              new_user = await caller.assignment.assignUserToTask({ email: input.new_emails[i], task_id: input.task_id });
+          }
+
+          for (let j = 0; j < assignments.length; j++) {
+              const ass = assignments[j];
+              try {
+                  await caller.assignment.update({ id: ass.id, updates: { ...ass, annotator_id: new_user } });
+                  stats.success++;
+              } catch {
+                  stats.failed++;
+              }
+          }
+
+          annotators[i].email = input.new_emails[i];
+        }
+      }
+      
+      const flat_annotators: Annotator[] = JSON.parse(JSON.stringify(annotators))
+
+      if (stats.success && !stats.failed) {
+        return {message: "All the assignments have been reassigned", annotators: flat_annotators} 
+      } else if (!stats.success && !stats.failed) {
+        return {message: "No changes have been made", annotators: flat_annotators}
+      } else if (stats.success && stats.failed) {
+        throw new TRPCError({message: "Some assignment updates failed", code: "INTERNAL_SERVER_ERROR"})
+      } else if (!stats.success && stats.failed) {
+        throw new TRPCError({message: "All assignment updates failed", code: "INTERNAL_SERVER_ERROR"})
+      }
+      
+      throw new TRPCError({message: "Undefined case", code: "INTERNAL_SERVER_ERROR"})
+    }),
+
   findById: protectedProcedure
     .input(z.number().int())
     .use((opts) =>

--- a/lawnotation-ui/server/trpc/routers/task.router.ts
+++ b/lawnotation-ui/server/trpc/routers/task.router.ts
@@ -5,6 +5,7 @@ import type { Annotation, Task, User, Annotator } from "~/types";
 import type { Context } from "../context";
 import { appRouter } from ".";
 import type { Database } from "~/types/supabase";
+import { zValidEmail } from "~/utils/validators";
 
 const ZTaskFields = z.object({
   name: z.string(),

--- a/lawnotation-ui/server/trpc/routers/user.router.ts
+++ b/lawnotation-ui/server/trpc/routers/user.router.ts
@@ -6,6 +6,20 @@ import { zValidEmail } from '~/utils/validators';
 
 export const userRouter = router({
 
+  'clearInviteMetadata': protectedProcedure
+    .mutation(async ({ ctx }) => {
+      const serviceClient = ctx.getSupabaseServiceRoleClient();
+      const user_metadata = ctx.user.user_metadata;
+      console.log(1, user_metadata)
+      if (user_metadata.assigned_task_id)
+        user_metadata.assigned_task_id = null;
+      console.log(2, user_metadata)
+
+      const update = await serviceClient.auth.admin.updateUserById(ctx.user.id, {user_metadata});
+      console.log(3, update.data.user?.user_metadata)
+      console.log(5, update.data.user?.id)
+    }),
+
   'findById': protectedProcedure
     .input(
       z.number().int()

--- a/lawnotation-ui/server/trpc/routers/user.router.ts
+++ b/lawnotation-ui/server/trpc/routers/user.router.ts
@@ -2,11 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod'
 import { authorizer, protectedProcedure, publicProcedure, router } from '~/server/trpc'
 import type { User } from '~/types';
-
-// const ZUserFields = z.object({
-//   email: z.string().email(),
-//   role: z.union([z.literal("editor"), z.literal("annotator")])
-// });
+import { zValidEmail } from '~/utils/validators';
 
 export const userRouter = router({
 
@@ -24,7 +20,7 @@ export const userRouter = router({
 
   'findByEmail': protectedProcedure
     .input(
-      z.string().email()
+      zValidEmail
     )
     .query(async ({ ctx, input: email }) => {
       const { data, error } = await ctx.supabase.from("users").select().eq('email', email).single();
@@ -66,30 +62,31 @@ export const userRouter = router({
     }),
 
   // TODO: definitely test!
-  'inviteUser': protectedProcedure
-    .input(
-      z.object({
-        email: z.string().email(),
-        redirectTo: z.string().url()
-      })
-    )
-    .query(async ({ ctx, input }) => {
-      const serviceClient = ctx.getSupabaseServiceRoleClient()
-      const { data, error } = await serviceClient.auth.admin.generateLink({
-        type: "magiclink",
-        email: input.email,
-        options: {
-          redirectTo: input.redirectTo
-        } 
-      })
+  // 'inviteUser': protectedProcedure
+  //   .input(
+  //     z.object({
+  //       email: z.string().email(),
+  //       redirectTo: z.string().url()
+  //     })
+  //   )
+  //   .query(async ({ ctx, input }) => {
+  //     const serviceClient = ctx.getSupabaseServiceRoleClient()
+  //     const { data, error } = await serviceClient.auth.admin.generateLink({
+  //       type: "magiclink",
+  //       email: input.email,
+  //       options: {
+  //         redirectTo: input.redirectTo
+  //       } 
+  //     })
       
-      if (error)
-        throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error in users.inviteUser: ${error.message}`});
-      return data;
-    }),
+  //     if (error)
+  //       throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error in users.inviteUser: ${error.message}`});
+  //     return data;
+  //   }),
+  
   'generateLink': protectedProcedure
     .input(
-      z.string().email()
+      zValidEmail
     )
     .use(opts => authorizer(opts, async () => false))
     .query(async ({ctx, input: email}) => {
@@ -107,7 +104,7 @@ export const userRouter = router({
 
   'otpLogin': publicProcedure
     .input(
-      z.string().email()
+      zValidEmail
     )
     .query(async ({ctx, input: email}) => {
       const login = await ctx.supabase.auth.signInWithOtp({ email: email })

--- a/lawnotation-ui/supabase/config.toml
+++ b/lawnotation-ui/supabase/config.toml
@@ -134,5 +134,9 @@ vector_port = 54328
 backend = "postgres"
 
 [auth.email.template.magic_link]
-subject = "You are invited to Acme Inc"
+subject = "Your login code for Lawnotation"
 content_path = "./supabase/templates/magic-link.html"
+
+[auth.email.template.invite]
+subject = "You are invited to Lawnotation"
+content_path = "./supabase/templates/invite.html"

--- a/lawnotation-ui/supabase/templates/invite.html
+++ b/lawnotation-ui/supabase/templates/invite.html
@@ -1,0 +1,4 @@
+<h2>You have been invited</h2>
+
+<p>You have been invited to create a user on {{ .SiteURL }}.</p>
+<p>To accept this invite, go to {{ .SiteURL }}/acceptInvite#email={{.Email}}, and enter the following 6-digit code: {{ .Token }}</p>

--- a/lawnotation-ui/supabase/templates/invite.html
+++ b/lawnotation-ui/supabase/templates/invite.html
@@ -1,4 +1,6 @@
 <h2>You have been invited</h2>
-
 <p>You have been invited to create a user on {{ .SiteURL }}.</p>
-<p>To accept this invite, go to {{ .SiteURL }}/acceptInvite#email={{.Email}}, and enter the following 6-digit code: {{ .Token }}</p>
+<p>
+  To accept this invite, go to <a href="{{ .SiteURL }}/auth/accept-invite#{{.Email}}">{{ .SiteURL }}/auth/accept-invite#{{.Email}}</a>,
+  and enter the following 6-digit code: {{ .Token }}
+</p>

--- a/lawnotation-ui/utils/validators.ts
+++ b/lawnotation-ui/utils/validators.ts
@@ -1,0 +1,3 @@
+import z from "zod";
+
+export const zValidEmail = z.union([z.string().email(), z.string().regex(/@localhost$/)]);


### PR DESCRIPTION
Since the authentication flow recently changed to logging using an OTP-token instead of a magic-link, the invites sent out to task-assignees should be respectively updated. This pull requests proposes various changes for enabling this feature. 

To make this work, new assignees will be sent an email with a link that has their email-address prefilled. On this page they are asked to provide the OTP-token from the email. Note that this is technically equivalent to the general login flow, and since they have been invited, they can also go to the general login-page and login as usual. Any time a user - new or existing - is assigned to a task, their metadata is updated to include the new `task_id`. When they (re-)log-in, they will see a flash message on the home page indicating that they're assigned to a new task and can start annotating with the provided link.

The logic for inviting users has been implemented for the task import page, the manual creation of assignments page and the updating of task assignments page.