### PR TITLE
feat: exclusively allow db access from backend

### DIFF
--- a/lawnotation-ui/server/trpc/context.ts
+++ b/lawnotation-ui/server/trpc/context.ts
@@ -13,10 +13,7 @@ export async function createContext(event: H3Event) {
   const authorization = getRequestHeader(event, 'authorization')
 
   let user = null;
-  const supabase = await serverSupabaseClient<Database>(event);
-  const getSupabaseServiceRoleClient = () => {
-    return serverSupabaseServiceRole<Database>(event);
-  }
+  const supabase = await serverSupabaseServiceRole<Database>(event);
 
   if (authorization) {
 
@@ -31,8 +28,7 @@ export async function createContext(event: H3Event) {
   
   return {
     user,
-    supabase,
-    getSupabaseServiceRoleClient
+    supabase
   }
 }
 

--- a/lawnotation-ui/server/trpc/routers/assignment.router.ts
+++ b/lawnotation-ui/server/trpc/routers/assignment.router.ts
@@ -51,13 +51,11 @@ export const assignmentRouter = router({
       })
     )
     .query(async ({ctx, input}) => {
-      const serviceClient = ctx.getSupabaseServiceRoleClient();
-
-      const email_found = (await serviceClient.from('users').select('id').eq('email', input.email).maybeSingle());
+      const email_found = (await ctx.supabase.from('users').select('id').eq('email', input.email).maybeSingle());
       let user_id: User['id'] | null = null;
       if (!email_found.data) {
         // email is a new user
-        const invite = await serviceClient.auth.admin.inviteUserByEmail(input.email, {data: {assigned_task_id: input.task_id}})
+        const invite = await ctx.supabase.auth.admin.inviteUserByEmail(input.email, {data: {assigned_task_id: input.task_id}})
 
         if (invite.error)
           throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error inviting: ${invite.error.message}`});
@@ -67,7 +65,7 @@ export const assignmentRouter = router({
         // email is already an user
         user_id = email_found.data.id as string;
 
-        await serviceClient.auth.admin.updateUserById(user_id, {user_metadata: {assigned_task_id: input.task_id}})
+        await ctx.supabase.auth.admin.updateUserById(user_id, {user_metadata: {assigned_task_id: input.task_id}})
       
         // ...
         console.log(`Hypothetically sending notification to user ${user_id} that it is assigned to new task`)
@@ -87,8 +85,7 @@ export const assignmentRouter = router({
       })
     )
     .query(async ({ctx, input}) => {
-      const serviceClient = ctx.getSupabaseServiceRoleClient();
-      const invite = await serviceClient.auth.admin.inviteUserByEmail(input.email, {data: {invited_task_id: input.task_id}})
+      const invite = await ctx.supabase.auth.admin.inviteUserByEmail(input.email, {data: {invited_task_id: input.task_id}})
 
       if (invite.error)
         throw new TRPCError({code: "INTERNAL_SERVER_ERROR", message: `Error inviting: ${invite.error.message}`});

--- a/lawnotation-ui/server/trpc/routers/user.router.ts
+++ b/lawnotation-ui/server/trpc/routers/user.router.ts
@@ -8,13 +8,12 @@ export const userRouter = router({
 
   'clearInviteMetadata': protectedProcedure
     .mutation(async ({ ctx }) => {
-      const serviceClient = ctx.getSupabaseServiceRoleClient();
       const user_metadata = ctx.user.user_metadata;
       
       if (user_metadata.assigned_task_id)
         user_metadata.assigned_task_id = null;
 
-      const update = await serviceClient.auth.admin.updateUserById(ctx.user.id, {user_metadata});
+      const update = await ctx.supabase.auth.admin.updateUserById(ctx.user.id, {user_metadata});
     }),
 
   'findById': protectedProcedure
@@ -81,8 +80,7 @@ export const userRouter = router({
   //     })
   //   )
   //   .query(async ({ ctx, input }) => {
-  //     const serviceClient = ctx.getSupabaseServiceRoleClient()
-  //     const { data, error } = await serviceClient.auth.admin.generateLink({
+  //     const { data, error } = await ctx.supabase.auth.admin.generateLink({
   //       type: "magiclink",
   //       email: input.email,
   //       options: {
@@ -102,8 +100,7 @@ export const userRouter = router({
     .use(opts => authorizer(opts, async () => false))
     .query(async ({ctx, input: email}) => {
       const config = useRuntimeConfig();
-      const client = ctx.getSupabaseServiceRoleClient();
-      const { data, error } = await client.auth.admin.generateLink({
+      const { data, error } = await ctx.supabase.auth.admin.generateLink({
         type: "magiclink",
         email: email,
         options: { redirectTo: `${config.public.baseURL}/auth/validate` },

--- a/lawnotation-ui/supabase/migrations/20230912140145_remote_commit.sql
+++ b/lawnotation-ui/supabase/migrations/20230912140145_remote_commit.sql
@@ -439,60 +439,6 @@ ALTER TABLE ONLY "public"."tasks"
 ALTER TABLE ONLY "public"."users"
     ADD CONSTRAINT "users_id_fkey" FOREIGN KEY ("id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
 
-CREATE POLICY "Allow Post to everyone" ON "public"."annotations" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Allow update to everyone" ON "public"."annotations" FOR UPDATE USING (true) WITH CHECK (true);
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."annotation_relations" FOR DELETE USING (true);
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."assignments" FOR DELETE USING (true);
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."documents" FOR DELETE USING (true);
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."labelsets" FOR DELETE USING (("auth"."uid"() = "editor_id"));
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."projects" FOR DELETE USING (true);
-
-CREATE POLICY "Enable delete for users based on user_id" ON "public"."tasks" FOR DELETE USING (true);
-
-CREATE POLICY "Enable delete for users for everone (TODO)" ON "public"."annotations" FOR DELETE USING (true);
-
-CREATE POLICY "Enable insert for authenticated users only" ON "public"."annotation_relations" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable insert for authenticated users only" ON "public"."assignments" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable insert for authenticated users only" ON "public"."documents" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable insert for authenticated users only" ON "public"."labelsets" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable insert for authenticated users only" ON "public"."tasks" FOR INSERT WITH CHECK (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."annotation_relations" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."annotations" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."assignments" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."documents" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."labelsets" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."projects" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."tasks" FOR SELECT USING (true);
-
-CREATE POLICY "Enable read access for all users" ON "public"."users" FOR SELECT USING (true);
-
-CREATE POLICY "Enable update for users based on email" ON "public"."annotation_relations" FOR UPDATE USING (true) WITH CHECK (true);
-
-CREATE POLICY "Enable update for users based on email" ON "public"."assignments" FOR UPDATE USING (true) WITH CHECK (true);
-
-CREATE POLICY "Enable update for users based on email" ON "public"."labelsets" FOR UPDATE USING (("auth"."uid"() = "editor_id")) WITH CHECK (("auth"."uid"() = "editor_id"));
-
-CREATE POLICY "Users can update own profile." ON "public"."users" FOR UPDATE USING (true);
-
-CREATE POLICY "allow everyone to create project " ON "public"."projects" FOR INSERT WITH CHECK (true);
-
 ALTER TABLE "public"."annotation_relations" ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE "public"."annotations" ENABLE ROW LEVEL SECURITY;

--- a/lawnotation-ui/supabase/migrations/20231027095629_remote_schema.sql
+++ b/lawnotation-ui/supabase/migrations/20231027095629_remote_schema.sql
@@ -12,8 +12,6 @@ alter table "public"."users" alter column "role" set default 'annotator'::user_r
 
 drop type "public"."user_roles__old_version_to_be_dropped";
 
-alter table "public"."projects" disable row level security;
-
 alter table "public"."users" alter column "role" set default 'editor'::user_roles;
 
 alter table "public"."users" add constraint "users_id_fkey" FOREIGN KEY (id) REFERENCES auth.users(id) not valid;

--- a/lawnotation-ui/supabase/migrations/20240129134051_remote_schema.sql
+++ b/lawnotation-ui/supabase/migrations/20240129134051_remote_schema.sql
@@ -132,30 +132,3 @@ grant trigger on table "public"."publications" to "service_role";
 grant truncate on table "public"."publications" to "service_role";
 
 grant update on table "public"."publications" to "service_role";
-
-create policy "Enable insert for everyone"
-on "public"."publications"
-as permissive
-for insert
-to public
-with check (true);
-
-
-create policy "Enable read access for all users"
-on "public"."publications"
-as permissive
-for select
-to public
-using (true);
-
-
-create policy "Enable update for users based on email"
-on "public"."tasks"
-as permissive
-for update
-to public
-using (true)
-with check (true);
-
-
-

--- a/lawnotation-ui/supabase/migrations/20240304154635_remote_schema.sql
+++ b/lawnotation-ui/supabase/migrations/20240304154635_remote_schema.sql
@@ -41,22 +41,3 @@ begin
 end;
 $function$
 ;
-
-create policy "Enable delete for users based on user_id"
-on "public"."publications"
-as permissive
-for delete
-to public
-using (true);
-
-
-create policy "Enable update for users based on email"
-on "public"."publications"
-as permissive
-for update
-to public
-using (true)
-with check (true);
-
-
-

--- a/lawnotation-ui/supabase/migrations/20240314085233_revoke_privileges.sql
+++ b/lawnotation-ui/supabase/migrations/20240314085233_revoke_privileges.sql
@@ -1,7 +1,10 @@
 -- inspired from: https://github.com/orgs/supabase/discussions/21647#discussion-6289771
 
+-- disable public openapi page
 ALTER ROLE authenticator SET pgrst.openapi_mode TO 'disabled';
+NOTIFY pgrst, 'reload config';
 
+-- revoke access to tables from anon and authenticated
 REVOKE USAGE ON SCHEMA public FROM anon, authenticated;
 REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
 REVOKE ALL PRIVILEGES ON ALL ROUTINES IN SCHEMA public FROM anon, authenticated;

--- a/lawnotation-ui/supabase/migrations/20240314085233_revoke_privileges.sql
+++ b/lawnotation-ui/supabase/migrations/20240314085233_revoke_privileges.sql
@@ -1,0 +1,11 @@
+-- inspired from: https://github.com/orgs/supabase/discussions/21647#discussion-6289771
+
+ALTER ROLE authenticator SET pgrst.openapi_mode TO 'disabled';
+
+REVOKE USAGE ON SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL ROUTINES IN SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;


### PR DESCRIPTION
This PR:
- removes policies for RLS,
- removes the contradicting `DISABLE ROW LEVEL SECURITY` for the project table,
- replaces supabase client on server with supabase servicerole client (in definition and utilization),
- revokes privileges for anon and authenticated according to [this discussion](https://github.com/orgs/supabase/discussions/21647), omitting the `service_role`
- disables PostgREST's OpenAPI spec endpoint according to [that same](https://github.com/orgs/supabase/discussions/21647) discussion

@CvdL-UM: I'm creating a PR and request your to review these changes since I have tried running the Cypress tests but am running into some errors that seem to be unrelated to my changes. Can you please verify that my changes introduce no problems?