### PR TITLE
Refactor table remove all button

### DIFF
--- a/lawnotation-ui/components/Table.vue
+++ b/lawnotation-ui/components/Table.vue
@@ -25,16 +25,28 @@
         <slot name="heading"></slot>
         <span class="flex-grow" v-if="props.selectable">
           
-          <button
-            v-show="total > 0"
-            @click="removeAll"
-            type="button"
-            style="outline: none"
-            class="mr-2 text-red-700 hover:text-white border border-red-700 hover:bg-red-800 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-xs px-5 py-2.5 text-center"
-            data-test="remove-all"
-          >
-            Remove all ({{ total }})
-          </button>
+          <Button 
+            v-show="total > 0" 
+            type="button" 
+            icon="pi pi-ellipsis-v" 
+            link 
+            @click="(event) => removeAllMenu.toggle(event)" 
+            aria-haspopup="true" 
+            aria-controls="remove-all-menu" 
+            data-test="remove-all-menu-button" 
+          />
+          <Menu ref="removeAllMenu" id="remove-all-menu" :popup="true" :model="[{
+              label: `Remove all (${ total })`,
+              command: removeAll
+            }]"
+            :pt="{
+              label: 'text-red-700',
+              content: {
+                'data-test': 'remove-all'
+              }
+            }"
+            :ptOptions="{ mergeProps: true }"
+          />
           <button
             v-show="checkedIds.length"
             @click="removeSelected(checkedIds)"
@@ -358,6 +370,8 @@ const props = withDefaults(
     name: "1",
   }
 );
+
+const removeAllMenu = ref();
 
 const columns = tableColumns[props.endpoint];
 

--- a/lawnotation-ui/components/Table.vue
+++ b/lawnotation-ui/components/Table.vue
@@ -40,7 +40,7 @@
               command: removeAll
             }]"
             :pt="{
-              label: 'text-red-700',
+              label: 'text-[#f05252]',
               content: {
                 'data-test': 'remove-all'
               }

--- a/lawnotation-ui/components/Table.vue
+++ b/lawnotation-ui/components/Table.vue
@@ -47,16 +47,17 @@
             }"
             :ptOptions="{ mergeProps: true }"
           />
-          <button
+          <Button 
             v-show="checkedIds.length"
-            @click="removeSelected(checkedIds)"
             type="button"
-            style="outline: none"
-            class="text-red-700 hover:text-white border border-red-700 hover:bg-red-800 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-xs px-5 py-2.5 text-center"
-            data-test="remove-selected-rows"
-          >
-            Remove selected rows ({{ checkedIds.length }})
-          </button>
+            :label="`Remove selected rows (${ checkedIds.length })`"
+            severity="danger"
+            outlined
+            @click="removeSelected(checkedIds)"
+            :pt="{ label: 'text-xs' }"
+            :ptOptions="{ mergeProps: true }"
+            data-test="remove-selected-rows" 
+          />
         </span>
         <span
           class="flex"

--- a/lawnotation-ui/cypress/e2e/03-projects.cy.ts
+++ b/lawnotation-ui/cypress/e2e/03-projects.cy.ts
@@ -27,7 +27,8 @@ describe('Testing projects and tasks with the editor account', () => {
         cy.get('button').contains('Confirm').click()
         cy.get('a[data-test="view-task-link"]').should("have.length", 2)
 
-        cy.get('[data-test="tasks-table"]').find('button[data-test="remove-all"]').click()
+        cy.get('[data-test="tasks-table"]').find('button[data-test="remove-all-menu-button"]').click()
+        cy.get('div[data-test="remove-all"]').click()
         cy.get('button').contains('Confirm').click()
         cy.get('a[data-test="view-task-link"]').should("have.length", 0)
 
@@ -38,7 +39,8 @@ describe('Testing projects and tasks with the editor account', () => {
         cy.get('button').contains('Confirm').click()
         cy.get('a[data-test="view-project-link"]').should("have.length", 2)
 
-        cy.get('button[data-test="remove-all"]').click()
+        cy.get('button[data-test="remove-all-menu-button"]').click()
+        cy.get('div[data-test="remove-all"]').click()
         cy.get('button').contains('Confirm').click()
         cy.get('a[data-test="view-project-link"]').should("have.length", 0)
     })
@@ -63,7 +65,8 @@ describe('Testing projects and tasks with the editor account', () => {
         cy.get('td').contains('Task3').should('exist')
 
         cy.get('a[data-test="projects-link"]').click()
-        cy.get('button[data-test="remove-all"]').click()
+        cy.get('button[data-test="remove-all-menu-button"]').click()
+        cy.get('div[data-test="remove-all"]').click()
         cy.get('button').contains('Confirm').click()
         cy.get('a[data-test="view-project-link"]').should("have.length", 0)
     })

--- a/lawnotation-ui/cypress/e2e/04-assignments.cy.ts
+++ b/lawnotation-ui/cypress/e2e/04-assignments.cy.ts
@@ -100,7 +100,7 @@ describe('Assign a project to annotators as the editor', () => {
 
         cy.get('button[data-pc-section="closebutton"').click({ force: true })
 
-        cy.get('button[data-test="kebab-button"').click()
+        cy.get('button[data-test="options-menu-button"').click()
         cy.get('div[data-test="duplicate-task"').click()
         cy.get('button[data-test="metrics-button"').click()
 

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -25,7 +25,7 @@
                 data-test="metrics-button" />
             </NuxtLink>
             <Button type="button" label="Export / Publish" outlined @click="exportModalVisible = true" data-test="export-publish-button" />
-            <Button type="button" icon="pi pi-ellipsis-v" link @click="(event) => optionsMenu.toggle(event)" aria-haspopup="true" aria-controls="options-menu" data-test="kebab-button" />
+            <Button type="button" icon="pi pi-ellipsis-v" link @click="(event) => optionsMenu.toggle(event)" aria-haspopup="true" aria-controls="options-menu" data-test="options-menu-button" />
             <Menu ref="optionsMenu" id="options-menu" :model="[{label: 'Duplicate Task', icon: 'pi pi-clone', command: replicateTask}]" :popup="true"
               :pt="{
                 content: {

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/index.vue
@@ -25,8 +25,8 @@
                 data-test="metrics-button" />
             </NuxtLink>
             <Button type="button" label="Export / Publish" outlined @click="exportModalVisible = true" data-test="export-publish-button" />
-            <Button type="button" icon="pi pi-ellipsis-v" link @click="(event) => overlayMenu.toggle(event)" aria-haspopup="true" aria-controls="overlay_menu" data-test="kebab-button" />
-            <Menu ref="overlayMenu" id="overlay_menu" :model="[{label: 'Duplicate Task', icon: 'pi pi-clone', command: replicateTask}]" :popup="true"
+            <Button type="button" icon="pi pi-ellipsis-v" link @click="(event) => optionsMenu.toggle(event)" aria-haspopup="true" aria-controls="options-menu" data-test="kebab-button" />
+            <Menu ref="optionsMenu" id="options-menu" :model="[{label: 'Duplicate Task', icon: 'pi pi-clone', command: replicateTask}]" :popup="true"
               :pt="{
                 content: {
                   'data-test': 'duplicate-task'
@@ -160,7 +160,7 @@ const totalAmountOfDocs = await $trpc.document.totalAmountOfDocs.query(task.proj
 const total_docs = totalAmountOfDocs ?? 0;
 const number_of_docs = ref<number>(total_docs);
 const number_of_fixed_docs = ref<number>(total_docs);
-const overlayMenu = ref()
+const optionsMenu = ref()
 
 const labels = await $trpc.labelset.findById.query(+task.labelset_id);
 


### PR DESCRIPTION
- Remove all is now hidden under a kebab button
- Remove selected rows button is replaced with PrimeVue Button
- Remove all menu item now uses the same red as the PrimeVue danger Button

![image](https://github.com/MaastrichtU-BISS/lawnotation/assets/93982741/c07d0291-87d9-420f-ae71-9967336b12d7)

![image](https://github.com/MaastrichtU-BISS/lawnotation/assets/93982741/d8c248fd-f74d-41c9-b9bd-c9161e35a88b)
