### PR TITLE
Support annotation Excel file export for single annotators

### DIFF
--- a/lawnotation-ui/components/DifficultyMetricsModal.vue
+++ b/lawnotation-ui/components/DifficultyMetricsModal.vue
@@ -61,7 +61,7 @@
                   />
                 </svg>
                 <p class="ml-2 text-sm font-medium text-gray-900 dark:text-white">
-                  {{ modelValue?.average.toFixed(2) }} average
+                  {{ modelValue?.average?.toFixed(2) }} average
                 </p>
               </div>
               <p class="inline text-sm font-medium text-gray-500 dark:text-gray-400">

--- a/lawnotation-ui/components/DifficultyMetricsModal.vue
+++ b/lawnotation-ui/components/DifficultyMetricsModal.vue
@@ -113,7 +113,7 @@
 </template>
 <script setup lang="ts">
 import type { DifficultyMetricResult } from "~/utils/metrics";
-const props = defineProps<{
+const { modelValue } = defineProps<{
   modelValue: DifficultyMetricResult;
 }>();
 </script>

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -620,7 +620,7 @@ async function download_all(data: any) {
         const workBookConfidence = await getConfidenceSheet(
           data.task_id,
           data.annotators.length,
-          data.annotatorOrEmpty,
+          data.annotatorsOrEmpty,
           [document]
         );
 

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -543,73 +543,75 @@ async function download_all(data: any) {
     (selectedDocuments.value.length + 1) * labelsOptions.length * 3 +
     (selectedDocuments.value.length + 1);
   try {
+    if (data.documents.length > 1) {
     // All confidence
-    try {
-      const workBookConfidence = await getConfidenceSheet(
-        data.task_id,
-        data.annotators.length,
-        data.annotatorOrEmpty,
-        data.documentsOrEmpty
-      );
+      try {
+        const workBookConfidence = await getConfidenceSheet(
+          data.task_id,
+          data.annotators.length,
+          data.annotatorOrEmpty,
+          data.documentsOrEmpty
+        );
 
+        results.push({
+          wb: getZippeableBlob(workBookConfidence),
+          name: `_confidence.xlsx`,
+        });
+        download_progress.value.current++;
+      } catch (error) { console.log(error) }
+
+      // All metrics
+      const workbookMetrics = XLSX.utils.book_new();
+      const workbookAnnotations = XLSX.utils.book_new();
+      const workbookDescriptive = XLSX.utils.book_new();
+      for (let i = 0; i < data.labelsOptions.length; i++) {
+        const label = data.labelsOptions[i];
+        const metrics = await compute_metrics(
+          data.task_id,
+          label,
+          data.documentsOrEmpty,
+          data.annotators,
+          data.annotatorsOrEmpty,
+          data.tolerance,
+          data.byWords,
+          data.hideNonText,
+          data.contained,
+          data.documentsData,
+          data.documentsOptions
+        );
+
+        const metrics_sheet = await getMetricsSheet(
+          metrics,
+          label,
+          data.documentsOrEmpty,
+          data
+        );
+        const metrics_sample = metrics[0].table ?? metrics[2].table!;
+        const annotations_sheet = await getAnnotationsSheet(metrics_sample);
+        const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
+          metrics_sample,
+          data.annotators
+        );
+
+        XLSX.utils.book_append_sheet(workbookMetrics, metrics_sheet, label.substring(0, 31));
+        XLSX.utils.book_append_sheet(workbookAnnotations, annotations_sheet, label.substring(0, 31));
+        XLSX.utils.book_append_sheet(workbookDescriptive, descriptive_anns_sheet, label.substring(0, 31));
+
+        download_progress.value.current += 3;
+      }
       results.push({
-        wb: getZippeableBlob(workBookConfidence),
-        name: `_confidence.xlsx`,
+        wb: getZippeableBlob(workbookMetrics),
+        name: `_metrics.xlsx`,
       });
-      download_progress.value.current++;
-    } catch (error) { console.log(error) }
-
-    // All metrics
-    const workbookMetrics = XLSX.utils.book_new();
-    const workbookAnnotations = XLSX.utils.book_new();
-    const workbookDescriptive = XLSX.utils.book_new();
-    for (let i = 0; i < data.labelsOptions.length; i++) {
-      const label = data.labelsOptions[i];
-      const metrics = await compute_metrics(
-        data.task_id,
-        label,
-        data.documentsOrEmpty,
-        data.annotators,
-        data.annotatorsOrEmpty,
-        data.tolerance,
-        data.byWords,
-        data.hideNonText,
-        data.contained,
-        data.documentsData,
-        data.documentsOptions
-      );
-
-      const metrics_sheet = await getMetricsSheet(
-        metrics,
-        label,
-        data.documentsOrEmpty,
-        data
-      );
-      const metrics_sample = metrics[0].table ?? metrics[2].table!;
-      const annotations_sheet = await getAnnotationsSheet(metrics_sample);
-      const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
-        metrics_sample,
-        data.annotators
-      );
-
-      XLSX.utils.book_append_sheet(workbookMetrics, metrics_sheet, label.substring(0, 31));
-      XLSX.utils.book_append_sheet(workbookAnnotations, annotations_sheet, label.substring(0, 31));
-      XLSX.utils.book_append_sheet(workbookDescriptive, descriptive_anns_sheet, label.substring(0, 31));
-
-      download_progress.value.current += 3;
+      results.push({
+        wb: getZippeableBlob(workbookAnnotations),
+        name: `_annotations.xlsx`,
+      });
+      results.push({
+        wb: getZippeableBlob(workbookDescriptive),
+        name: `_descriptive.xlsx`,
+      });
     }
-    results.push({
-      wb: getZippeableBlob(workbookMetrics),
-      name: `_metrics.xlsx`,
-    });
-    results.push({
-      wb: getZippeableBlob(workbookAnnotations),
-      name: `_annotations.xlsx`,
-    });
-    results.push({
-      wb: getZippeableBlob(workbookDescriptive),
-      name: `_descriptive.xlsx`,
-    });
 
     // Per document
     for (let i = 0; i < data.documents.length; i++) {

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -685,7 +685,7 @@ async function download_all(data: any) {
     }
 
     return results;
-  } catch (error) { console.log(error) }
+  } catch (error) { console.error(error) }
   return [];
 }
 

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -213,7 +213,7 @@
         </div>
       </div>
     </div>
-    <DifficultyMetricsModal v-model="metrics_result.difficulty"></DifficultyMetricsModal>
+    <DifficultyMetricsModal :modelValue="metrics_result.difficulty!"></DifficultyMetricsModal>
   </div>
 </template>
 <script setup lang="ts">

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -544,21 +544,19 @@ async function download_all(data: any) {
     (selectedDocuments.value.length + 1);
   try {
     if (data.documents.length > 1) {
-    // All confidence
-      try {
-        const workBookConfidence = await getConfidenceSheet(
-          data.task_id,
-          data.annotators.length,
-          data.annotatorOrEmpty,
-          data.documentsOrEmpty
-        );
+      // All confidence
+      const workBookConfidence = await getConfidenceSheet(
+        data.task_id,
+        data.annotators.length,
+        data.annotatorOrEmpty,
+        data.documentsOrEmpty
+      );
 
-        results.push({
-          wb: getZippeableBlob(workBookConfidence),
-          name: `_confidence.xlsx`,
-        });
-        download_progress.value.current++;
-      } catch (error) { console.log(error) }
+      results.push({
+        wb: getZippeableBlob(workBookConfidence),
+        name: `_confidence.xlsx`,
+      });
+      download_progress.value.current++;
 
       // All metrics
       const workbookMetrics = XLSX.utils.book_new();
@@ -618,23 +616,20 @@ async function download_all(data: any) {
       const document = data.documents[i];
       const filename = document + "-" + data.documentsData[document].name.split(".")[0];
       // per document confidence
-      try {
-        const workBookConfidence = await getConfidenceSheet(
-          data.task_id,
-          data.annotators.length,
-          data.annotatorsOrEmpty,
-          [document]
-        );
+      const workBookConfidence = await getConfidenceSheet(
+        data.task_id,
+        data.annotators.length,
+        data.annotatorsOrEmpty,
+        [document]
+      );
 
-        results.push({
-          wb: getZippeableBlob(workBookConfidence),
-          name: `${filename}_confidence.xlsx`,
-        });
+      results.push({
+        wb: getZippeableBlob(workBookConfidence),
+        name: `${filename}_confidence.xlsx`,
+      });
 
-        download_progress.value.current++;
-      } catch (error) {
-        console.log(error);
-      }
+      download_progress.value.current++;
+
       const workbookMetrics = XLSX.utils.book_new();
       const workbookAnnotations = XLSX.utils.book_new();
       const workbookDescriptive = XLSX.utils.book_new();

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -567,9 +567,9 @@ async function download_all(data: any) {
     for (let i = 0; i < data.documents.length; i++) {
       const document = data.documents[i];
       const filename = document + "-" + data.documentsData[document].name.split(".")[0];
-      
+
       const { workBookConfidence, workbookMetrics, workbookAnnotations, workbookDescriptive } = await createWorkBooks(data, document);
-      
+
       results.push({
         wb: getZippeableBlob(workBookConfidence),
         name: `${filename}_confidence.xlsx`,
@@ -605,6 +605,16 @@ async function createWorkBooks(data: any, document?: any) {
     document ? [document] : data.documentsOrEmpty
   );
   download_progress.value.current++;
+
+  const annotations = await getAnnotations(
+    data.task_id,
+    data.label,
+    data.documents,
+    data.annotatorsOrEmpty,
+    data.byWords,
+    data.hideNonText,
+  );
+  
   // All metrics
   const workbookMetrics = XLSX.utils.book_new();
   const workbookAnnotations = XLSX.utils.book_new();
@@ -622,7 +632,8 @@ async function createWorkBooks(data: any, document?: any) {
       data.hideNonText,
       data.contained,
       data.documentsData,
-      data.documentsOptions
+      data.documentsOptions,
+      annotations
     );
 
     const metrics_sheet = await getMetricsSheet(

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -544,59 +544,11 @@ async function download_all(data: any) {
     (selectedDocuments.value.length + 1);
   try {
     if (data.documents.length > 1) {
-      // All confidence
-      const workBookConfidence = await getConfidenceSheet(
-        data.task_id,
-        data.annotators.length,
-        data.annotatorOrEmpty,
-        data.documentsOrEmpty
-      );
-
+      const { workBookConfidence, workbookMetrics, workbookAnnotations, workbookDescriptive } = await createWorkBooks(data);
       results.push({
         wb: getZippeableBlob(workBookConfidence),
         name: `_confidence.xlsx`,
       });
-      download_progress.value.current++;
-
-      // All metrics
-      const workbookMetrics = XLSX.utils.book_new();
-      const workbookAnnotations = XLSX.utils.book_new();
-      const workbookDescriptive = XLSX.utils.book_new();
-      for (let i = 0; i < data.labelsOptions.length; i++) {
-        const label = data.labelsOptions[i];
-        const metrics = await compute_metrics(
-          data.task_id,
-          label,
-          data.documentsOrEmpty,
-          data.annotators,
-          data.annotatorsOrEmpty,
-          data.tolerance,
-          data.byWords,
-          data.hideNonText,
-          data.contained,
-          data.documentsData,
-          data.documentsOptions
-        );
-
-        const metrics_sheet = await getMetricsSheet(
-          metrics,
-          label,
-          data.documentsOrEmpty,
-          data
-        );
-        const metrics_sample = metrics[0].table ?? metrics[2].table!;
-        const annotations_sheet = await getAnnotationsSheet(metrics_sample);
-        const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
-          metrics_sample,
-          data.annotators
-        );
-
-        XLSX.utils.book_append_sheet(workbookMetrics, metrics_sheet, label.substring(0, 31));
-        XLSX.utils.book_append_sheet(workbookAnnotations, annotations_sheet, label.substring(0, 31));
-        XLSX.utils.book_append_sheet(workbookDescriptive, descriptive_anns_sheet, label.substring(0, 31));
-
-        download_progress.value.current += 3;
-      }
       results.push({
         wb: getZippeableBlob(workbookMetrics),
         name: `_metrics.xlsx`,
@@ -615,55 +567,13 @@ async function download_all(data: any) {
     for (let i = 0; i < data.documents.length; i++) {
       const document = data.documents[i];
       const filename = document + "-" + data.documentsData[document].name.split(".")[0];
-      // per document confidence
-      const workBookConfidence = await getConfidenceSheet(
-        data.task_id,
-        data.annotators.length,
-        data.annotatorsOrEmpty,
-        [document]
-      );
-
+      
+      const { workBookConfidence, workbookMetrics, workbookAnnotations, workbookDescriptive } = await createWorkBooks(data, document);
+      
       results.push({
         wb: getZippeableBlob(workBookConfidence),
         name: `${filename}_confidence.xlsx`,
       });
-
-      download_progress.value.current++;
-
-      const workbookMetrics = XLSX.utils.book_new();
-      const workbookAnnotations = XLSX.utils.book_new();
-      const workbookDescriptive = XLSX.utils.book_new();
-      for (let j = 0; j < data.labelsOptions.length; j++) {
-        // per document metrics
-        const label = data.labelsOptions[j];
-        const metrics = await compute_metrics(
-          data.task_id,
-          label,
-          [document],
-          data.annotators,
-          data.annotatorsOrEmpty,
-          data.tolerance,
-          data.byWords,
-          data.hideNonText,
-          data.contained,
-          data.documentsData,
-          data.documentsOptions
-        );
-
-        const metrics_sheet = await getMetricsSheet(metrics, label, [document], data);
-        const metrics_sample = metrics[0].table ?? metrics[2].table!;
-        const annotations_sheet = await getAnnotationsSheet(metrics_sample);
-        const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
-          metrics_sample,
-          data.annotators
-        );
-
-        XLSX.utils.book_append_sheet(workbookMetrics, metrics_sheet, label.substring(0, 31));
-        XLSX.utils.book_append_sheet(workbookAnnotations, annotations_sheet, label.substring(0, 31));
-        XLSX.utils.book_append_sheet(workbookDescriptive, descriptive_anns_sheet, label.substring(0, 31));
-
-        download_progress.value.current += 3;
-      }
 
       results.push({
         wb: getZippeableBlob(workbookMetrics),
@@ -684,6 +594,58 @@ async function download_all(data: any) {
     return results;
   } catch (error) { console.error(error) }
   return [];
+}
+
+async function createWorkBooks(data: any, document?: any) {
+  // All confidence
+  const workBookConfidence = await getConfidenceSheet(
+    data.task_id,
+    data.annotators.length,
+    data.annotatorOrEmpty,
+    document ? [document] : data.documentsOrEmpty
+  );
+  download_progress.value.current++;
+  // All metrics
+  const workbookMetrics = XLSX.utils.book_new();
+  const workbookAnnotations = XLSX.utils.book_new();
+  const workbookDescriptive = XLSX.utils.book_new();
+  for (let i = 0; i < data.labelsOptions.length; i++) {
+    const label = data.labelsOptions[i];
+    const metrics = await compute_metrics(
+      data.task_id,
+      label,
+      document ? [document] : data.documentsOrEmpty,
+      data.annotators,
+      data.annotatorsOrEmpty,
+      data.tolerance,
+      data.byWords,
+      data.hideNonText,
+      data.contained,
+      data.documentsData,
+      data.documentsOptions
+    );
+
+    const metrics_sheet = await getMetricsSheet(
+      metrics,
+      label,
+      data.documentsOrEmpty,
+      data
+    );
+    const metrics_sample = metrics[0].table ?? metrics[2].table!;
+    const annotations_sheet = await getAnnotationsSheet(metrics_sample);
+    const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
+      metrics_sample,
+      data.annotators
+    );
+
+    XLSX.utils.book_append_sheet(workbookMetrics, metrics_sheet, label.substring(0, 31));
+    XLSX.utils.book_append_sheet(workbookAnnotations, annotations_sheet, label.substring(0, 31));
+    XLSX.utils.book_append_sheet(workbookDescriptive, descriptive_anns_sheet, label.substring(0, 31));
+
+    download_progress.value.current += 3;
+  }
+
+  return { workBookConfidence, workbookMetrics, workbookAnnotations, workbookDescriptive };
 }
 
 async function getMetricsSheet(

--- a/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
+++ b/lawnotation-ui/pages/projects/[project_id]/tasks/[task_id]/metrics/index.vue
@@ -66,7 +66,8 @@
                     <div
                       class="relative w-11 h-6 bg-gray-200 rounded-full peer peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600">
                     </div>
-                    <span class="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300 justify-self-start">Word</span>
+                    <span
+                      class="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300 justify-self-start">Word</span>
                   </label>
                   <InfoToolTip :id="'tooltip_annotation_word'"
                     :text="'Choose between comparing entire chunks with annotations or individual words\' annotations.'" />
@@ -584,7 +585,7 @@ async function download_all(data: any) {
         data.documentsOrEmpty,
         data
       );
-      const metrics_sample = metrics[0].table?? metrics[2].table!;
+      const metrics_sample = metrics[0].table ?? metrics[2].table!;
       const annotations_sheet = await getAnnotationsSheet(metrics_sample);
       const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
         metrics_sample,
@@ -653,7 +654,7 @@ async function download_all(data: any) {
         );
 
         const metrics_sheet = await getMetricsSheet(metrics, label, [document], data);
-        const metrics_sample = metrics[0].table?? metrics[2].table!;
+        const metrics_sample = metrics[0].table ?? metrics[2].table!;
         const annotations_sheet = await getAnnotationsSheet(metrics_sample);
         const descriptive_anns_sheet = await getDescriptiveAnnotatorSheet(
           metrics_sample,
@@ -755,7 +756,7 @@ async function getAnnotationsSheet(table: RangeLabel[]) {
           annotator: k,
           start: r.start,
           end: r.end,
-          text: r.text.length <= 1000 ? r.text : `${r.text.substring(0,100)} ... ${r.text.substring(900, 1000)}`,
+          text: r.text.length <= 1000 ? r.text : `${r.text.substring(0, 100)} ... ${r.text.substring(900, 1000)}`,
           confidence: r.confidences[k],
           value: v,
         });

--- a/lawnotation-ui/server/api/metrics/get_annotations.post.ts
+++ b/lawnotation-ui/server/api/metrics/get_annotations.post.ts
@@ -32,9 +32,7 @@ export default eventHandler(async (event) => {
   const annotations = await annotationsPromise;
   const documentsData = await documentsDataPromise;
 
-  let result = [];
-
-  result = await getNonAnnotations(
+  let result = await getNonAnnotations(
     annotations,
     documentsData[0],
     documentsData[1]


### PR DESCRIPTION
So far, when you clicked the Download All button under Analyze Metrics, the annotations Excel file would be empty for a single annotator. This was caused by the fact that no metrics are calculated, since there is only one annotator, so inter-coder reliability calculations are not possible. However, all the annotations are still available. So, with some tweaks to the Export All workflow, single annotator annotation exports are now supported.